### PR TITLE
Troubleshoot qr code netlify deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,7 @@
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Add Netlify SPA fallback redirect to resolve 404 errors for client-side routes accessed via QR codes.

Direct access to client-side routes (e.g., `/student`) on Netlify resulted in a 404 without a SPA fallback, making QR codes pointing to these routes appear non-functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-00adff48-4b9a-4568-9b0b-1f1117927c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00adff48-4b9a-4568-9b0b-1f1117927c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

